### PR TITLE
Fix stat message for less than one day time range

### DIFF
--- a/__tests__/maybeDead.test.js
+++ b/__tests__/maybeDead.test.js
@@ -55,7 +55,7 @@ describe('maybe dead', () => {
     MockDate.set(moment(dateToTest));
 
     const slimbot = createMockedSlimbot((chatId, text) => {
-      expect(text).toMatch('*user1* - наверное помер (писал менее 1 дня назад)')
+      expect(text).toMatch('*user1* - наверное помер (писал менее 1 дня назад)');
     });
 
     await sendTestMessage({

--- a/__tests__/maybeDead.test.js
+++ b/__tests__/maybeDead.test.js
@@ -55,7 +55,7 @@ describe('maybe dead', () => {
     MockDate.set(moment(dateToTest));
 
     const slimbot = createMockedSlimbot((chatId, text) => {
-      expect(text).toMatch('*user1* - наверное помер (писал 1 день назад)');
+      expect(text).toMatch('*user1* - наверное помер (писал менее 1 дня назад)')
     });
 
     await sendTestMessage({

--- a/src/statistics/maybeDiedStat.js
+++ b/src/statistics/maybeDiedStat.js
@@ -33,8 +33,10 @@ const render = (collectedStat) => {
 
     const today = moment();
     const lastMessageDate = moment(topUser.date * 1000);
-    const diff = today.diff(lastMessageDate, 'days') || 1;
-    return `*${getFullUserName(topUser)}* - наверное помер (писал ${diff} ${getDays(diff)} назад)`;
+    const diff = today.diff(lastMessageDate, 'days');
+    const timeMessage = diff < 1 ? 'менее 1 дня' : `${diff} ${getDays(diff)}`
+
+    return `*${getFullUserName(topUser)}* - наверное помер (писал ${timeMessage} назад)`;
   }
   return '';
 };

--- a/src/statistics/maybeDiedStat.js
+++ b/src/statistics/maybeDiedStat.js
@@ -34,7 +34,7 @@ const render = (collectedStat) => {
     const today = moment();
     const lastMessageDate = moment(topUser.date * 1000);
     const diff = today.diff(lastMessageDate, 'days');
-    const timeMessage = diff < 1 ? 'менее 1 дня' : `${diff} ${getDays(diff)}`
+    const timeMessage = diff < 1 ? 'менее 1 дня' : `${diff} ${getDays(diff)}`;
 
     return `*${getFullUserName(topUser)}* - наверное помер (писал ${timeMessage} назад)`;
   }


### PR DESCRIPTION
Close https://github.com/qelphybox/hakeshonassybot/issues/141

Изменения предложенные в пул реквесте:
- Изменено сообщение ачивки "наверное помер" с "1 день назад" на менее "1 дня назад" для временного промежутка менее чем день

@qelphybox @svyborov посмотрите, пожалуйста
